### PR TITLE
fix: add byte[] as jackson trusted class

### DIFF
--- a/src/main/java/org/opensourceway/sbom/manager/batch/job/SbomBatchConfigurer.java
+++ b/src/main/java/org/opensourceway/sbom/manager/batch/job/SbomBatchConfigurer.java
@@ -1,0 +1,153 @@
+package org.opensourceway.sbom.manager.batch.job;
+
+import org.opensourceway.sbom.constants.BatchContextConstants;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.batch.core.configuration.annotation.BatchConfigurer;
+import org.springframework.batch.core.explore.JobExplorer;
+import org.springframework.batch.core.explore.support.JobExplorerFactoryBean;
+import org.springframework.batch.core.launch.JobLauncher;
+import org.springframework.batch.core.launch.support.SimpleJobLauncher;
+import org.springframework.batch.core.repository.JobRepository;
+import org.springframework.batch.core.repository.dao.Jackson2ExecutionContextStringSerializer;
+import org.springframework.batch.core.repository.support.JobRepositoryFactoryBean;
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.boot.autoconfigure.batch.BatchProperties;
+import org.springframework.boot.autoconfigure.transaction.TransactionManagerCustomizers;
+import org.springframework.boot.context.properties.PropertyMapper;
+import org.springframework.orm.jpa.JpaTransactionManager;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.PlatformTransactionManager;
+
+import javax.persistence.EntityManagerFactory;
+import javax.sql.DataSource;
+
+/**
+ * refactor by org.springframework.boot.autoconfigure.batch.JpaBatchConfigurer
+ */
+@Component
+public class SbomBatchConfigurer implements BatchConfigurer, InitializingBean {
+
+    private static final Logger logger = LoggerFactory.getLogger(SbomBatchConfigurer.class);
+
+    private final BatchProperties properties;
+
+    private final DataSource dataSource;
+
+    private PlatformTransactionManager transactionManager;
+
+    private final TransactionManagerCustomizers transactionManagerCustomizers;
+
+    private final EntityManagerFactory entityManagerFactory;
+
+    private JobRepository jobRepository;
+
+    private JobLauncher jobLauncher;
+
+    private JobExplorer jobExplorer;
+
+    protected SbomBatchConfigurer(BatchProperties properties, DataSource dataSource, TransactionManagerCustomizers transactionManagerCustomizers, EntityManagerFactory entityManagerFactory) {
+        this.properties = properties;
+        this.dataSource = dataSource;
+        this.transactionManagerCustomizers = transactionManagerCustomizers;
+        this.entityManagerFactory = entityManagerFactory;
+    }
+
+    @Override
+    public JobRepository getJobRepository() {
+        return this.jobRepository;
+    }
+
+    @Override
+    public PlatformTransactionManager getTransactionManager() {
+        return this.transactionManager;
+    }
+
+    @Override
+    public JobLauncher getJobLauncher() {
+        return this.jobLauncher;
+    }
+
+    @Override
+    public JobExplorer getJobExplorer() throws Exception {
+        return this.jobExplorer;
+    }
+
+    @Override
+    public void afterPropertiesSet() {
+        initialize();
+    }
+
+    public void initialize() {
+        try {
+            this.transactionManager = buildTransactionManager();
+            this.jobRepository = createJobRepository();
+            this.jobLauncher = createJobLauncher();
+            this.jobExplorer = createJobExplorer();
+        } catch (Exception ex) {
+            throw new IllegalStateException("Unable to initialize Spring Batch", ex);
+        }
+    }
+
+    protected JobExplorer createJobExplorer() throws Exception {
+        PropertyMapper map = PropertyMapper.get();
+        JobExplorerFactoryBean factory = new JobExplorerFactoryBean();
+        factory.setDataSource(this.dataSource);
+        map.from(this.properties.getJdbc()::getTablePrefix).whenHasText().to(factory::setTablePrefix);
+        // custom serializer
+        factory.setSerializer(new Jackson2ExecutionContextStringSerializer(BatchContextConstants.JACKSON_SERIALIZER_TRUSTED_CLASS_NAME));
+        factory.afterPropertiesSet();
+        return factory.getObject();
+    }
+
+    protected JobLauncher createJobLauncher() throws Exception {
+        SimpleJobLauncher jobLauncher = new SimpleJobLauncher();
+        jobLauncher.setJobRepository(getJobRepository());
+        jobLauncher.afterPropertiesSet();
+        return jobLauncher;
+    }
+
+    protected JobRepository createJobRepository() throws Exception {
+        JobRepositoryFactoryBean factory = new JobRepositoryFactoryBean();
+        PropertyMapper map = PropertyMapper.get();
+        map.from(this.dataSource).to(factory::setDataSource);
+        map.from(this::determineIsolationLevel).whenNonNull().to(factory::setIsolationLevelForCreate);
+        map.from(this.properties.getJdbc()::getTablePrefix).whenHasText().to(factory::setTablePrefix);
+        map.from(this::getTransactionManager).to(factory::setTransactionManager);
+        // custom serializer
+        factory.setSerializer(new Jackson2ExecutionContextStringSerializer(BatchContextConstants.JACKSON_SERIALIZER_TRUSTED_CLASS_NAME));
+        factory.afterPropertiesSet();
+        return factory.getObject();
+    }
+
+    private PlatformTransactionManager buildTransactionManager() {
+        PlatformTransactionManager transactionManager = createTransactionManager();
+        if (this.transactionManagerCustomizers != null) {
+            this.transactionManagerCustomizers.customize(transactionManager);
+        }
+        return transactionManager;
+    }
+
+    protected String determineIsolationLevel() {
+        BatchProperties.Isolation isolation = this.properties.getJdbc().getIsolationLevelForCreate();
+
+        if (isolation != null) {
+            return toIsolationName(isolation);
+        } else {
+            logger.warn("JPA does not support custom isolation levels, so locks may not be taken when launching Jobs. "
+                    + "To silence this warning, set 'spring.batch.jdbc.isolation-level-for-create' to 'default'.");
+            return toIsolationName(BatchProperties.Isolation.DEFAULT);
+        }
+    }
+
+    protected PlatformTransactionManager createTransactionManager() {
+        return new JpaTransactionManager(this.entityManagerFactory);
+    }
+
+    private static final String PREFIX = "ISOLATION_";
+
+    String toIsolationName(BatchProperties.Isolation isolation) {
+        return PREFIX + isolation.name();
+    }
+
+}

--- a/src/test/java/org/opensourceway/sbom/manager/utils/Jackson2ExecutionContextStringSerializerTests.java
+++ b/src/test/java/org/opensourceway/sbom/manager/utils/Jackson2ExecutionContextStringSerializerTests.java
@@ -1,0 +1,73 @@
+package org.opensourceway.sbom.manager.utils;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.batch.core.repository.dao.Jackson2ExecutionContextStringSerializer;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+/**
+ * reference to https://github.com/spring-projects/spring-batch/pull/3787/files
+ */
+public class Jackson2ExecutionContextStringSerializerTests {
+
+    /**
+     * 测试自定义信任类
+     *
+     * @throws IOException
+     */
+    @Test
+    public void testAdditionalTrustedClass() throws IOException {
+        // given
+        Jackson2ExecutionContextStringSerializer serializer =
+                new Jackson2ExecutionContextStringSerializer("java.util.Locale");
+        Map<String, Object> context = new HashMap<>(1);
+        context.put("locale", Locale.getDefault());
+
+        // when
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        serializer.serialize(context, outputStream);
+        InputStream inputStream = new ByteArrayInputStream(outputStream.toByteArray());
+        Map<String, Object> deserializedContext = serializer.deserialize(inputStream);
+
+        // then
+        Locale locale = (Locale) deserializedContext.get("locale");
+        assertThat(locale).isNotNull();
+    }
+
+
+    /**
+     * 测试多个自定义信任类
+     *
+     * @throws IOException
+     */
+    @Test
+    public void testByteArrayTrustedClass() throws IOException {
+        String content = "StingBytesTest";
+
+        // given
+        Jackson2ExecutionContextStringSerializer serializer =
+                new Jackson2ExecutionContextStringSerializer("[B", "java.util.Locale");
+        Map<String, Object> context = new HashMap<>(1);
+        context.put("bytes", content.getBytes(StandardCharsets.UTF_8));
+
+        // when
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        serializer.serialize(context, outputStream);
+        InputStream inputStream = new ByteArrayInputStream(outputStream.toByteArray());
+        Map<String, Object> deserializedContext = serializer.deserialize(inputStream);
+
+        // then
+        byte[] bytes = (byte[]) deserializedContext.get("bytes");
+        assertThat(content.equals(new String(bytes))).isTrue();
+    }
+
+}

--- a/utils/src/main/java/org/opensourceway/sbom/constants/BatchContextConstants.java
+++ b/utils/src/main/java/org/opensourceway/sbom/constants/BatchContextConstants.java
@@ -32,4 +32,6 @@ public class BatchContextConstants {
 
     public final static String BUILD_IN_BATCH_CHUNK_FAILED_INPUT_KEY = "INPUTS";
 
+    public final static String[] JACKSON_SERIALIZER_TRUSTED_CLASS_NAME = new String[]{"[B"};
+
 }


### PR DESCRIPTION
Resolve spring batch restart failure when context contains byte[]

![image](https://user-images.githubusercontent.com/86641897/207085603-32154315-9696-42df-a055-77cbd593e2cc.png)


